### PR TITLE
fix(typings): Remove constructor typing

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,5 @@
 // interface declaration from log4js-node.
 interface Logger {
-    new(dispatch: Function, name: string): Logger;
     level: string;
     log(...args: any[]): void;
     isLevelEnabled(level?: string): boolean;


### PR DESCRIPTION
When using the api with the new typings, ts complains about the Logger object does not match the interface because of the new method. 