### PR TITLE
Export `shutdown` function

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -29,7 +29,9 @@ const checkForLog4js = () => {
 
 const log4js = checkForLog4js();
 const loggerFn =  log4js ? log4js.getLogger : () => new Logger();
+const shutdown =  log4js ? log4js.shutdown : () => {};
 
 module.exports = {
-  getLogger: loggerFn
+  getLogger: loggerFn,
+  shutdown: shutdown
 };


### PR DESCRIPTION
As a user may use async logging function, the `shutdown()` may be required: this PR add that to the module exports.